### PR TITLE
v1.1: RLE prefix for vflags/kflags/bools columns (-3.3% size on bench, -55-90% on homogeneous arrays)

### DIFF
--- a/sdk/src/decoder.js
+++ b/sdk/src/decoder.js
@@ -374,15 +374,28 @@ class Decoder {
   }
 
   getVflags() {
+    const len = this.len
+    if (len === 0) return
+    // v1.1 RLE prefix: 2 bits.
+    const mode = this.n(2)
+    const vflags = this.vflags
+    if (mode === 0) {
+      for (let i = 0; i < len; i++) vflags.push(0)
+      return
+    }
+    if (mode === 1) {
+      for (let i = 0; i < len; i++) vflags.push(1)
+      return
+    }
+    if (mode !== 2) {
+      throw new Error("ARJSON decoder: invalid vflags mode " + mode)
+    }
     const maxBits = this.o.length * 8 - this.c
-    if (this.len > maxBits) {
+    if (len > maxBits) {
       throw new Error("ARJSON decoder: vflags length exceeds remaining buffer")
     }
-    // Inline n(1) for the hot bit-by-bit flag read. Avoids 1721 method
-    // calls + function-frame allocation for each 1-bit read.
+    // Inline n(1) for the hot bit-by-bit flag read.
     const o = this.o
-    const len = this.len
-    const vflags = this.vflags
     let c = this.c
     for (let i = 0; i < len; i++) {
       vflags.push((o[c >>> 3] >> (7 - (c & 7))) & 1)
@@ -393,12 +406,25 @@ class Decoder {
 
   getKflags() {
     const need = this.key_length - 1 - this.keylen
+    if (need <= 0) return
+    const mode = this.n(2)
+    const kflags = this.kflags
+    if (mode === 0) {
+      for (let i = 0; i < need; i++) kflags.push(0)
+      return
+    }
+    if (mode === 1) {
+      for (let i = 0; i < need; i++) kflags.push(1)
+      return
+    }
+    if (mode !== 2) {
+      throw new Error("ARJSON decoder: invalid kflags mode " + mode)
+    }
     const maxBits = this.o.length * 8 - this.c
     if (need > maxBits) {
       throw new Error("ARJSON decoder: kflags length exceeds remaining buffer")
     }
     const o = this.o
-    const kflags = this.kflags
     let c = this.c
     for (let i = 0; i < need; i++) {
       kflags.push((o[c >>> 3] >> (7 - (c & 7))) & 1)
@@ -605,10 +631,28 @@ class Decoder {
   }
 
   getBools() {
+    // First count how many bools to read so we can dispatch on the
+    // 2-bit mode prefix (skips it if the column is empty).
+    let count = 0
     for (let _v of this.vtypes) {
       let v = Array.isArray(_v) ? _v[3] : _v
-      if (v === 3) this.bools.push(this.n(1) === 1)
+      if (v === 3) count++
     }
+    if (count === 0) return
+    const mode = this.n(2)
+    const bools = this.bools
+    if (mode === 0) {
+      for (let i = 0; i < count; i++) bools.push(false)
+      return
+    }
+    if (mode === 1) {
+      for (let i = 0; i < count; i++) bools.push(true)
+      return
+    }
+    if (mode !== 2) {
+      throw new Error("ARJSON decoder: invalid bools mode " + mode)
+    }
+    for (let i = 0; i < count; i++) bools.push(this.n(1) === 1)
   }
 
   getNums() {

--- a/sdk/src/encoder.js
+++ b/sdk/src/encoder.js
@@ -239,14 +239,18 @@ class Encoder {
 
   push_vflag(flag) {
     this.add_vflags(flag, 1)
+    if (flag) this.vflags_one++; else this.vflags_zero++
   }
 
   push_bool(bool) {
-    this.add_bools(bool ? 1 : 0, 1)
+    const v = bool ? 1 : 0
+    this.add_bools(v, 1)
+    if (v) this.bools_one++; else this.bools_zero++
   }
 
   push_kflag(flag) {
     this.add_kflags(flag, 1)
+    if (flag) this.kflags_one++; else this.kflags_zero++
   }
 
   get_diff(v, prev) {
@@ -282,6 +286,7 @@ class Encoder {
     if (vfused === 0) this.vflags[vfidx] = flag
     else this.vflags[vfidx] = (this.vflags[vfidx] << 1) | flag
     this.vflags_len = vflen + 1
+    if (flag) this.vflags_one++; else this.vflags_zero++
     this._push_vlink(v2, isDiff, this.dcount)
     this.rcount++
   }
@@ -305,6 +310,7 @@ class Encoder {
     if (kfused === 0) this.kflags[kfidx] = flag
     else this.kflags[kfidx] = (this.kflags[kfidx] << 1) | flag
     this.kflags_len = kflen + 1
+    if (flag) this.kflags_one++; else this.kflags_zero++
     this._push_klink(v2, isDiff, this.dcount)
   }
 
@@ -750,6 +756,14 @@ class Encoder {
     this.vflags_len = 0
     this.kflags_len = 0
     this.bools_len = 0
+    // Counters for v1.1 RLE-flag column encoding. We track zeros/ones
+    // as columns are populated so dump() can emit a 2-bit prefix:
+    //   00 = all zeros (no body)
+    //   01 = all ones (no body)
+    //   10 = mixed (followed by raw body bits)
+    this.vflags_zero = 0; this.vflags_one = 0
+    this.kflags_zero = 0; this.kflags_one = 0
+    this.bools_zero = 0; this.bools_one = 0
     this.keys_len = 0
     this.types_len = 0
     this.nums_len = 0
@@ -855,16 +869,40 @@ class Encoder {
       this.add_dc(0, 1)
       this.short_dc(this.rcount)
     }
+    // v1.1 RLE-flag encoding: prefix vflags, kflags, bools columns with
+    // a 2-bit mode selector when the column is non-empty:
+    //   00 = all zeros (no body)
+    //   01 = all ones  (no body)
+    //   10 = mixed     (followed by raw len bits)
+    //   11 = reserved
+    // Empty columns (len=0) emit nothing. Structurally vflags_len > 0
+    // in structured mode, but kflags_len and bools_len can be 0.
+    const vfMode = this.vflags_len === 0 ? -1
+      : this.vflags_zero === this.vflags_len ? 0
+      : this.vflags_one === this.vflags_len ? 1 : 2
+    const kfMode = this.kflags_len === 0 ? -1
+      : this.kflags_zero === this.kflags_len ? 0
+      : this.kflags_one === this.kflags_len ? 1 : 2
+    const bMode = this.bools_len === 0 ? -1
+      : this.bools_zero === this.bools_len ? 0
+      : this.bools_one === this.bools_len ? 1 : 2
+    const vfHeader = vfMode === -1 ? 0 : 2
+    const kfHeader = kfMode === -1 ? 0 : 2
+    const bHeader = bMode === -1 ? 0 : 2
+    const vfBody = vfMode === 2 ? this.vflags_len : 0
+    const kfBody = kfMode === 2 ? this.kflags_len : 0
+    const bBody = bMode === 2 ? this.bools_len : 0
+
     const totalBits =
       this.dc_len +
-      this.vflags_len +
+      vfHeader + vfBody +
       this.vlinks_len +
-      this.kflags_len +
+      kfHeader + kfBody +
       this.klinks_len +
       this.keys_len +
       this.types_len +
       this.nums_len +
-      this.bools_len +
+      bHeader + bBody +
       this.kvals_len +
       this.vals_len +
       this.strdiffs_len
@@ -873,26 +911,59 @@ class Encoder {
     const outLength = finalBits / 8
     const out = new Uint8Array(outLength)
 
-    // Hot path: pack all column bits into `out`. Was implemented as
-    // closure-based writeBits/writeBuffer; V8 had trouble inlining
-    // them since they captured 3 mutable variables. Straight inline
-    // loop with unrolled column ordering is much faster.
+    // Pack columns. For vflags/kflags/bools, write the 2-bit prefix first
+    // (when len > 0) then the body only if mode is mixed.
     let outIndex = 0
     let accumulator = 0
     let accBits = 0
-    const _bufs = [
-      this.dc, this.vflags, this.vlinks, this.kflags, this.klinks,
-      this.keys, this.kvals, this.types, this.bools, this.nums,
-      this.vals, this.strdiffs,
-    ]
-    const _lens = [
-      this.dc_len, this.vflags_len, this.vlinks_len, this.kflags_len,
-      this.klinks_len, this.keys_len, this.kvals_len, this.types_len,
-      this.bools_len, this.nums_len, this.vals_len, this.strdiffs_len,
+    // Per-column entries are { buf, len, prefix, prefixBits }.
+    // prefixBits is 0 for columns without prefix and 2 for prefixed.
+    // For prefixed mode 0 or 1, the body length is 0.
+    const _cols = [
+      { buf: this.dc,        len: this.dc_len,        prefix: 0, prefixBits: 0 },
+      { buf: this.vflags,    len: vfBody,             prefix: vfMode | 0, prefixBits: vfHeader },
+      { buf: this.vlinks,    len: this.vlinks_len,    prefix: 0, prefixBits: 0 },
+      { buf: this.kflags,    len: kfBody,             prefix: kfMode | 0, prefixBits: kfHeader },
+      { buf: this.klinks,    len: this.klinks_len,    prefix: 0, prefixBits: 0 },
+      { buf: this.keys,      len: this.keys_len,      prefix: 0, prefixBits: 0 },
+      { buf: this.kvals,     len: this.kvals_len,     prefix: 0, prefixBits: 0 },
+      { buf: this.types,     len: this.types_len,     prefix: 0, prefixBits: 0 },
+      { buf: this.bools,     len: bBody,              prefix: bMode | 0, prefixBits: bHeader },
+      { buf: this.nums,      len: this.nums_len,      prefix: 0, prefixBits: 0 },
+      { buf: this.vals,      len: this.vals_len,      prefix: 0, prefixBits: 0 },
+      { buf: this.strdiffs,  len: this.strdiffs_len,  prefix: 0, prefixBits: 0 },
     ]
     for (let ci = 0; ci < 12; ci++) {
-      const buffer = _bufs[ci]
-      let remaining = _lens[ci]
+      const col = _cols[ci]
+      // Write prefix bits if any.
+      if (col.prefixBits > 0) {
+        let num = col.prefix
+        let numBits = col.prefixBits
+        while (numBits > 0) {
+          const free = 8 - accBits
+          if (numBits <= free) {
+            accumulator = (accumulator << numBits) | (num & ((1 << numBits) - 1))
+            accBits += numBits
+            numBits = 0
+            if (accBits === 8) {
+              out[outIndex++] = accumulator
+              accumulator = 0
+              accBits = 0
+            }
+          } else {
+            const shift = numBits - free
+            const part = num >>> shift
+            accumulator = (accumulator << free) | (part & ((1 << free) - 1))
+            out[outIndex++] = accumulator
+            num = num & ((1 << shift) - 1)
+            numBits -= free
+            accumulator = 0
+            accBits = 0
+          }
+        }
+      }
+      const buffer = col.buf
+      let remaining = col.len
       const buflen = buffer.length
       let bi = 0
       while (remaining > 0 && bi < buflen) {

--- a/sdk/test/golden.test.js
+++ b/sdk/test/golden.test.js
@@ -167,41 +167,44 @@ describe("golden: encoded sizes for canonical inputs", () => {
 })
 
 describe("golden: encoded sizes for compressible patterns", () => {
-  it("array of 100 sequential ints → 22 bytes", () => {
+  // v1.1: vflags/kflags/bools columns now use a 2-bit RLE prefix.
+  // For homogeneous columns (all-zero or all-one), the prefix replaces
+  // the entire raw bit body, yielding large size wins on these patterns.
+  it("array of 100 sequential ints → 10 bytes", () => {
     const a = []
     for (let i = 0; i < 100; i++) a.push(i)
-    assert.equal(enc(a).length, 22)
+    assert.equal(enc(a).length, 10)
   })
 
-  it("array of 100 identical strings → 137 bytes", () => {
+  it("array of 100 identical strings → 125 bytes", () => {
     const a = []
     for (let i = 0; i < 100; i++) a.push("repeated")
-    assert.equal(enc(a).length, 137)
+    assert.equal(enc(a).length, 125)
   })
 
-  it("array of 100 nulls → 19 bytes", () => {
+  it("array of 100 nulls → 7 bytes", () => {
     const a = []
     for (let i = 0; i < 100; i++) a.push(null)
+    assert.equal(enc(a).length, 7)
+  })
+
+  it("array of 100 alternating booleans → 19 bytes", () => {
+    const a = []
+    for (let i = 0; i < 100; i++) a.push(i % 2 === 0)
     assert.equal(enc(a).length, 19)
   })
 
-  it("array of 100 alternating booleans → 31 bytes", () => {
-    const a = []
-    for (let i = 0; i < 100; i++) a.push(i % 2 === 0)
-    assert.equal(enc(a).length, 31)
-  })
-
-  it("50 identical user records → 770 bytes", () => {
+  it("50 identical user records → 740 bytes", () => {
     const a = []
     for (let i = 0; i < 50; i++)
       a.push({ id: i, name: "Alice", role: "admin", active: true })
-    assert.equal(enc(a).length, 770)
+    assert.equal(enc(a).length, 740)
   })
 
-  it("array of 1000 sequential ints → 139 bytes", () => {
+  it("array of 1000 sequential ints → 14 bytes", () => {
     const a = []
     for (let i = 0; i < 1000; i++) a.push(i)
-    assert.equal(enc(a).length, 139)
+    assert.equal(enc(a).length, 14)
   })
 })
 


### PR DESCRIPTION
## Summary

Adds a 2-bit RLE mode prefix to the vflags, kflags, and bools columns. Homogeneous columns (very common in arrays of primitives) collapse from N raw bits to 2 prefix bits.

**This is a BREAKING format change vs v1.0.** Existing v1.0 payloads cannot be decoded by v1.1. Discussed below.

## Encoding

For each of vflags / kflags / bools, when the column is non-empty:

```
00 = all zeros, no body
01 = all ones,  no body
10 = mixed,     followed by raw len bits
11 = reserved (future use)
```

When the column is empty (kflags / bools can be empty), no prefix is emitted (same as v1.0).

The encoder tracks zero/one counts as columns are populated, then picks the mode at dump time. The decoder reads the 2-bit prefix and dispatches.

## Size results (full bench corpus, 34 workloads)

| pipeline | bytes | % msg | Δ |
|---|---:|---:|---:|
| msgpack | 28,195 | 100% | — |
| cbor-x  | 29,365 | 104.1% | — |
| arjson v1.0 | 17,654 | 62.6% | — |
| **arjson v1.1** | **17,075** | **60.6%** | **−3.3%** |

## Per-workload wins (largest)

| workload | v1.0 | v1.1 | Δ |
|---|---:|---:|---:|
| `arr_int_1000` | 139 B | **14 B** | **−90%** |
| `arr_null_100` | 19 B | **7 B** | **−63%** |
| `arr_int_100` | 22 B | **10 B** | **−55%** |
| `bool_array_500` | 134 B | **72 B** | **−46%** |
| `arr_bool_100` (alt) | 31 B | **19 B** | **−39%** |
| `arr_str_100_homog` | 137 B | 125 B | −9% |
| `redundant_users` | 983 B | 920 B | −6% |

## Where it costs bits

Tiny structured inputs (1-3 values with mixed flag patterns) pay 2-4 bits of prefix overhead with no body savings. Examples (no change in bench corpus):
- `tiny_obj` ({a:1, b:2}): 8 B
- `mixed_array` (12-element): 38 B

For workloads ≥50 B, the average gain is ~5%. For workloads ≥500 B (the realistic permanent-storage use case), it's 6-8%. The bench's many tiny workloads dilute the aggregate.

## Bug found and fixed during implementation

`kflags.need = key_length - 1 - keylen` can be **negative** in delta-update mode (when `keylen > key_length - 1`). The original code's `while (i < need)` correctly skipped when need ≤ 0; my new prefix-reader's `if (need === 0) return` was too narrow and led to misaligned bit reads on negative-need cases.

Fixed to `if (need <= 0) return`. All 1721 tests pass.

## Format compatibility

**v1.1 is NOT backward-compatible with v1.0.** Existing v1.0 payloads stored on chain or in databases cannot be decoded by v1.1, and vice versa. Two paths to deploy:

1. **Hard cutover** (this PR): re-encode all stored data with v1.1 at upgrade time.
2. **Extension gate** (follow-up PR): use the reserved `00000` byte prefix from `docs/format.md` to signal v1.1 payloads. v1.0 decoders correctly reject them; v1.1 decoders dispatch on the prefix. Backward compatibility preserved.

If the project requires backward compatibility, **defer this PR** and do option 2 in a separate change.

## Test plan

- [x] `npm test` — all 1721 tests pass
- [x] 6 golden tests updated with new (smaller) byte sizes
- [x] Round-trip validated on diverse inputs (homogeneous arrays, mixed structures, delta chains)
- [x] Bench script `node test/bench.js` runs cleanly across all 34 workloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)