### PR TITLE
docs: update format/benchmarks/README for v1.1 RLE change

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -80,10 +80,10 @@ fit.
 | Pipeline                                      | bytes |
 | --------------------------------------------- | ----: |
 | 50 documents × `json + brotli` (per document) | 5,336 |
-| 50 documents × `arjson + brotli`              | 5,100 |
-| ARJSON delta chain (raw)                      | 3,585 |
-| **ARJSON delta chain + zstd**                 | **684** |
+| 50 documents × `arjson + brotli` (v1.1)       | 5,081 |
+| ARJSON v1.1 delta chain (raw)                 | 3,618 |
+| **ARJSON v1.1 delta chain + zstd**            | **671** |
 
-ARJSON+zstd on the delta chain is **7.8× smaller than json+brotli per-document**,
+ARJSON+zstd on the delta chain is **8× smaller than json+brotli per-document**,
 preserves every historical state, and is byte-for-byte deterministic across
 encoders that pin the implementation version.

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -67,29 +67,32 @@ generated user records with predictable variation (`bench-beat-json-brotli.js`).
 | JSON                   | 41,348  |  100.0% |    146.6%  |
 | MessagePack            | 28,195  |   68.2% |    100.0%  |
 | CBOR (cbor-x)          | 29,365  |   71.0% |    104.1%  |
-| ARJSON                 | 17,654  |   42.7% |     62.6%  |
+| ARJSON v1.0            | 17,654  |   42.7% |     62.6%  |
+| **ARJSON v1.1**        | **17,075** | **41.3%** | **60.6%**  |
 
-ARJSON is **37% smaller than MessagePack** and **40% smaller than CBOR**
-overall. Per-workload, ARJSON wins on 24/34, ties on 5, loses by 1–2
-bytes on 5 (all sub-10-byte payloads).
+ARJSON v1.1 is **39% smaller than MessagePack** and **42% smaller than
+CBOR** overall. Per-workload, ARJSON wins on 24/34, ties on 5, loses
+by 1–2 bytes on 5 (all sub-10-byte payloads).
 
-Where ARJSON's lead is largest, in size-vs-MessagePack:
+Where ARJSON's lead is largest (v1.1 sizes, vs MessagePack):
 
 | Workload              | ARJSON / msgpack |
 | --------------------- | ---------------: |
-| `arr_int_1000`        |             5.3% |
-| `arr_str_100_homog`   |            15.2% |
-| `arr_null_100`        |            18.4% |
-| `arr_int_100`         |            21.4% |
-| `arr_bool_100`        |            30.1% |
-| `redundant_users`     |            33.3% |
-| `arr_obj_100_homog`   |            45.2% |
+| `arr_int_1000`        |             0.5% |
+| `arr_int_100`         |             9.7% |
+| `arr_str_100_homog`   |            13.8% |
+| `arr_null_100`        |             6.8% |
+| `arr_bool_100`        |            18.4% |
+| `bool_array_500`      |            14.3% |
+| `redundant_users`     |            31.2% |
+| `arr_obj_100_homog`   |            44.0% |
 | `float_array_100`     |            46.5% |
 | `wide_500`            |            56.9% |
 
 These are the workloads that exercise ARJSON's strongest features:
 delta-pack on sequential numbers, strmap dedup on repeated strings,
-type-pack on homogeneous arrays, columnar dedup on shape-repeated objects.
+type-pack on homogeneous arrays, columnar dedup on shape-repeated
+objects, and (new in v1.1) RLE on boolean-valued columns.
 
 ## Results: speed (encode/decode time)
 
@@ -142,15 +145,15 @@ the script), with various pipelines.
 | ----------------------------------------- | ----: | -----------: |
 | json (raw)                                | 7,134 |       133.7% |
 | json + brotli                             | 5,336 |       100.0% |
-| arjson (raw)                              | 4,900 |        91.8% |
-| arjson + brotli                           | 5,100 |        95.6% |
-| arjson + zstd                             | 5,550 |       104.0% |
-| arjson + zstd + trained dict              | 5,550 |       104.0% |
-| arjson + zstd + self-strmap-as-dict       | 5,550 |       104.0% |
-| arjson + brotli + strmap-prefix (sim)     | 6,706 |       125.7% |
+| **arjson v1.1 (raw)**                     | **4,881** |    **91.5%** |
+| arjson v1.1 + brotli                      | 5,081 |        95.2% |
+| arjson v1.1 + zstd                        | 5,531 |       103.7% |
+| arjson v1.1 + zstd + trained dict         | 5,531 |       103.7% |
+| arjson v1.1 + zstd + self-strmap-as-dict  | 5,531 |       103.7% |
+| arjson v1.1 + brotli + strmap-prefix (sim)| 6,722 |       126.0% |
 
 Even raw ARJSON beats `json + brotli` per-document on this homogeneous
-corpus (91.8%). Adding a downstream compressor doesn't help much because
+corpus (91.5%). Adding a downstream compressor doesn't help much because
 ARJSON has already extracted most redundancy. The trained-dictionary
 result equals the no-dict result, confirming that ARJSON's strmap is
 already serving the dictionary's role inline.
@@ -159,13 +162,13 @@ already serving the dictionary's role inline.
 
 | Pipeline                                  | bytes |   vs json+br |
 | ----------------------------------------- | ----: | -----------: |
-| arjson DELTA chain (raw)                  | 3,585 |        67.2% |
-| arjson DELTA + brotli                     |   710 |        13.3% |
-| arjson DELTA + zstd                       |   684 |        12.8% |
-| arjson DELTA + zstd + trained dict        |   692 |        13.0% |
-| arjson DELTA + zstd + self-strmap         |   684 |        12.8% |
+| arjson v1.1 DELTA chain (raw)             | 3,618 |        67.8% |
+| arjson v1.1 DELTA + brotli                |   664 |        12.4% |
+| arjson v1.1 DELTA + zstd                  |   671 |        12.6% |
+| arjson v1.1 DELTA + zstd + trained dict   |   667 |        12.5% |
+| arjson v1.1 DELTA + zstd + self-strmap    |   671 |        12.6% |
 
-The delta chain compresses to **~14 bytes per document state**, ~7.8×
+The delta chain compresses to **~13 bytes per document state**, ~8×
 smaller than json+brotli per-document. The zstd-with-self-strmap row
 matches the no-dict row because, again, ARJSON has already done the
 dictionary work inline.
@@ -199,8 +202,8 @@ a general compressor can achieve.
 | --------------------------------- | ----: |
 | json (concat)                     | 41,348 |
 | **json (concat) + brotli**        | **4,158** |
-| arjson (concat)                   | 17,654 |
-| arjson (concat) + brotli          |  4,669 |
+| arjson v1.1 (concat)              | 17,075 |
+| arjson v1.1 (concat) + brotli     |  4,605 |
 | msgpack (concat) + brotli         |  4,741 |
 | cbor (concat) + brotli            |  4,807 |
 

--- a/docs/delta-chains.md
+++ b/docs/delta-chains.md
@@ -50,16 +50,16 @@ snapshot-based encoding for the same history.
 Empirical comparison (50 user records mutated incrementally; full results
 in [benchmarks.md](./benchmarks.md)):
 
-| Storage of 50 historical states                 |  bytes | bytes/state |
-| ----------------------------------------------- | -----: | ----------: |
-| 50 full encodes (`json + brotli` per snapshot)  |  5,336 |        ~107 |
-| 50 full encodes (`arjson + brotli` per snapshot) |  5,100 |        ~102 |
-| ARJSON delta chain (raw)                        |  3,585 |        ~71  |
-| ARJSON delta chain + brotli                     |    710 |        ~14  |
-| ARJSON delta chain + zstd                       |    684 |        ~14  |
+| Storage of 50 historical states                  |  bytes | bytes/state |
+| ------------------------------------------------ | -----: | ----------: |
+| 50 full encodes (`json + brotli` per snapshot)   |  5,336 |        ~107 |
+| 50 full encodes (`arjson v1.1 + brotli` per snap) |  5,081 |        ~102 |
+| ARJSON v1.1 delta chain (raw)                    |  3,618 |        ~72  |
+| ARJSON v1.1 delta chain + brotli                 |    664 |        ~13  |
+| ARJSON v1.1 delta chain + zstd                   |    671 |        ~13  |
 
-The ARJSON delta chain stores **all 50 historical states** in 684 bytes —
-14 bytes per state amortized — and can reconstruct any prior state by
+The ARJSON delta chain stores **all 50 historical states** in 664 bytes —
+13 bytes per state amortized — and can reconstruct any prior state by
 replaying deltas. The snapshot pipelines store only the latest state at
 ≥100 bytes per copy if all history is to be retained.
 

--- a/docs/format.md
+++ b/docs/format.md
@@ -46,14 +46,14 @@ bits are organized into 13 groups (columns), each encoding one aspect of
 the document. The groups appear in a fixed order and are read sequentially:
 
 1. Value count (number of values in the document)
-2. Value flags (1 bit per value: delta-encoded or not)
+2. Value flags (RLE-prefixed, 1 bit per value: delta-encoded or not)
 3. Value links (references from each value to its parent key)
-4. Key flags (1 bit per key: delta-encoded or not)
+4. Key flags (RLE-prefixed, 1 bit per key: delta-encoded or not)
 5. Key links (parent references for keys)
 6. Key types (2 bits per key: array, object, base64 string, generic string)
 7. Keys (the key strings themselves)
 8. Data types (3 bits per value type)
-9. Boolean values (1 bit each)
+9. Boolean values (RLE-prefixed, 1 bit each)
 10. Number values (variable encoding)
 11. String values (variable encoding)
 12. String diffs (for delta-encoded string updates)
@@ -67,6 +67,29 @@ Each group exploits column-specific compression:
   indices on subsequent occurrences.**
 - **Keys with only base64url characters use 6-bit encoding rather than
   full LEB128.**
+- **Boolean-valued columns (`vflags`, `kflags`, `bools`) use a 2-bit
+  RLE mode prefix**: `00` (all zeros, no body), `01` (all ones, no
+  body), `10` (mixed, raw body bits follow), `11` (reserved). For
+  homogeneous columns this collapses N raw bits to 2 prefix bits;
+  for mixed columns it costs 2 bits of overhead.
+
+### Boolean-column RLE prefix (v1.1)
+
+Each non-empty column among `vflags`, `kflags`, `bools` is preceded
+by a 2-bit mode selector:
+
+```
+mode 00 → all zeros (column has expected length but no body bits)
+mode 01 → all ones  (column has expected length but no body bits)
+mode 10 → mixed     (column body is raw <expected length> bits)
+mode 11 → reserved
+```
+
+When the column is empty (length 0), no prefix is emitted — the
+adjacent columns abut directly. The expected length is determined
+from the document structure already parsed (value count for
+`vflags`, key chain length for `kflags`, count of boolean-typed
+values for `bools`).
 
 The detailed bit layout for each group is in
 `sdk/src/encoder.js` (encode side) and `sdk/src/decoder.js` (decode side).


### PR DESCRIPTION
## Summary

Refreshes the documentation to match the v1.1 RLE-prefix format change merged in #28.

## Changes

- **`docs/format.md`** — documents the new 2-bit RLE mode prefix on vflags / kflags / bools columns. Adds a dedicated subsection explaining the 4 modes (`00` all-zero, `01` all-one, `10` mixed, `11` reserved) and when the prefix is / isn't emitted.

- **`docs/benchmarks.md`** — refreshes total-bytes table to show v1.0 and v1.1 side-by-side (17,654 B → 17,075 B, −3.3%). Updates per-workload and pipeline tables with v1.1 numbers from `bench-beat-json-brotli.js`.

- **`docs/delta-chains.md`** — refreshes the 50-state delta-chain table. Chain+zstd now **671 B** (was 684 B); chain+brotli **664 B** (was 710). Per-state amortized: ~13 B/state (was ~14).

- **`docs/README.md`** — refreshes the headline measurement: delta chain + zstd is now **8× smaller** than `json+brotli` per-document (was 7.8×).

No source changes; doc-only PR. All 1721 tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)